### PR TITLE
Create project context from route and authorize based on user context

### DIFF
--- a/backend/UnitTests/UnitTests.csproj
+++ b/backend/UnitTests/UnitTests.csproj
@@ -16,6 +16,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="MongoDB.Analyzer" Version="1.1.0" />
+        <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="Shouldly" Version="4.1.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/backend/UnitTests/WebApi/Auth/ProjectAuthorizationHandlerTest.cs
+++ b/backend/UnitTests/WebApi/Auth/ProjectAuthorizationHandlerTest.cs
@@ -1,0 +1,55 @@
+using LanguageForge.Api.Entities;
+using LanguageForge.WebApi.Auth;
+using Microsoft.AspNetCore.Authorization;
+using static LanguageForge.UnitTests.WebApi.ContextHelpers;
+
+namespace LanguageForge.UnitTests.WebApi.Auth;
+
+public class ProjectAuthorizationHandlerTest
+{
+    [Fact]
+    public async Task FailsIfUserIsNotAuthorized()
+    {
+        // GIVEN a user that is not authorized
+        var user = new LfUser("test@testeroolaboom.fun", LfId<User>.Parse("User:6359f8855e3dc273d4662f2a"),
+            UserRole.User,
+            new[] {
+                new UserProjectRole("fun-language", ProjectRole.Manager),
+                new UserProjectRole("spooky-language", ProjectRole.Contributor),
+             });
+        var webContext = WebContext(user);
+        var projectContext = ProjectContext("missing-language");
+
+        // WHEN the handler is invoked
+        var handler = new ProjectAuthorizationHandler(webContext, projectContext);
+        var req = new ProjectAuthorizationRequirement();
+        var context = new AuthorizationHandlerContext(new IAuthorizationRequirement[] { req }, null, null);
+        await handler.HandleAsync(context);
+
+        // THEN the handler fails
+        context.HasFailed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task SucceedsIfUserIsAdmin()
+    {
+        // GIVEN an admin user
+        var user = new LfUser("test@testeroolaboom.fun", LfId<User>.Parse("User:6359f8855e3dc273d4662f2a"),
+            UserRole.SystemAdmin,
+            new[] {
+                new UserProjectRole("fun-language", ProjectRole.Manager),
+                new UserProjectRole("spooky-language", ProjectRole.Contributor),
+             });
+        var webContext = WebContext(user);
+        var projectContext = ProjectContext("missing-language");
+
+        // WHEN the handler is invoked
+        var handler = new ProjectAuthorizationHandler(webContext, projectContext);
+        var req = new ProjectAuthorizationRequirement();
+        var context = new AuthorizationHandlerContext(new IAuthorizationRequirement[] { req }, null, null);
+        await handler.HandleAsync(context);
+
+        // THEN the handler succeeds
+        context.HasSucceeded.ShouldBeTrue();
+    }
+}

--- a/backend/UnitTests/WebApi/ContextHelpers.cs
+++ b/backend/UnitTests/WebApi/ContextHelpers.cs
@@ -1,0 +1,22 @@
+using LanguageForge.WebApi;
+using LanguageForge.WebApi.Auth;
+using Moq;
+
+namespace LanguageForge.UnitTests.WebApi;
+
+public static class ContextHelpers
+{
+    public static ILfWebContext WebContext(LfUser user)
+    {
+        var contextMock = new Mock<ILfWebContext>();
+        contextMock.SetupGet(c => c.User).Returns(user);
+        return contextMock.Object;
+    }
+
+    public static ILfProjectContext ProjectContext(string projectCode)
+    {
+        var contextMock = new Mock<ILfProjectContext>();
+        contextMock.SetupGet(c => c.ProjectCode).Returns(projectCode);
+        return contextMock.Object;
+    }
+}

--- a/backend/WebApi/Auth/AuthSetup.cs
+++ b/backend/WebApi/Auth/AuthSetup.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.OpenApi.Models;
 
@@ -21,11 +22,14 @@ public static class AuthSetup
         services.AddSingleton<JwtService>();
         services.AddAuthorization(options =>
         {
+            options.AddPolicy(nameof(ProjectAuthorizationRequirement), policy => policy.Requirements.Add(new ProjectAuthorizationRequirement()));
+
             //fallback policy is used when there's no auth attribute.
             //default policy is when there's no parameters specified on the auth attribute
             //this will make sure that all endpoints require auth unless they have the AllowAnonymous attribute
-            options.FallbackPolicy = options.DefaultPolicy;
+            options.FallbackPolicy = AuthorizationPolicy.Combine(options.DefaultPolicy, options.GetPolicy(nameof(ProjectAuthorizationRequirement)));
         });
+        services.AddScoped<IAuthorizationHandler, ProjectAuthorizationHandler>();
         services.AddOptions<JwtOptions>()
             .BindConfiguration("Authentication:Jwt")
             .Validate(options => options.GoogleClientId != "==== replace ====",

--- a/backend/WebApi/Auth/JwtService.cs
+++ b/backend/WebApi/Auth/JwtService.cs
@@ -105,7 +105,7 @@ public class JwtService
         };
     }
 
-    public static LfUser ExtractLfUser(ClaimsPrincipal user)
+    public static LfUser? ExtractLfUser(ClaimsPrincipal user)
     {
         var emailClaim = user.FindFirstValue(EmailClaimType);
         var idClaim = user.FindFirstValue(JwtRegisteredClaimNames.Sub);
@@ -115,7 +115,7 @@ public class JwtService
         if (string.IsNullOrEmpty(emailClaim) || string.IsNullOrEmpty(idClaim) ||
             string.IsNullOrEmpty(roleClaim) || string.IsNullOrEmpty(projectRolesClaim))
         {
-            throw new ArgumentException($"User is missing required claims. Claims: {user.Claims}.");
+            return null;
         }
 
         var userId = LfId<User>.Parse(idClaim);

--- a/backend/WebApi/Auth/ProjectAuthorizationHandler.cs
+++ b/backend/WebApi/Auth/ProjectAuthorizationHandler.cs
@@ -1,0 +1,48 @@
+using LanguageForge.Api.Entities;
+using Microsoft.AspNetCore.Authorization;
+
+namespace LanguageForge.WebApi.Auth;
+
+public class ProjectAuthorizationRequirement : IAuthorizationRequirement { }
+
+public class ProjectAuthorizationHandler : AuthorizationHandler<ProjectAuthorizationRequirement>
+{
+    private readonly ILfWebContext _lfWebContext;
+    private readonly ILfProjectContext _lfProjectContext;
+
+    public ProjectAuthorizationHandler(ILfWebContext lfWebContext, ILfProjectContext lfProjectContext)
+    {
+        _lfWebContext = lfWebContext;
+        _lfProjectContext = lfProjectContext;
+    }
+
+    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, ProjectAuthorizationRequirement requirement)
+    {
+        var projectCode = _lfProjectContext.ProjectCode;
+        if (string.IsNullOrWhiteSpace(projectCode))
+        {
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        var lfUser = _lfWebContext.User;
+
+        if (lfUser == null)
+        {
+            context.Fail(new AuthorizationFailureReason(this, "User is not authenticated"));
+            return Task.CompletedTask;
+        }
+
+        if (lfUser.Role == UserRole.SystemAdmin
+            || lfUser.Projects.Any(p => p.ProjectCode == projectCode))
+        {
+            context.Succeed(requirement);
+        }
+        else
+        {
+            context.Fail(new AuthorizationFailureReason(this, $"User is not authorized for project: {projectCode}"));
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/backend/WebApi/Controllers/CommentController.cs
+++ b/backend/WebApi/Controllers/CommentController.cs
@@ -1,9 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
+using static LanguageForge.WebApi.Controllers.PathConstants;
 
 namespace LanguageForge.WebApi.Controllers;
 
 [ApiController]
-[Route("api/[controller]/{projectCode}/{entryId}")]
+[Route($"api/[controller]/{{{ProjectCode}}}/{{entryId}}")]
 public class CommentController : ControllerBase
 {
     [HttpGet("{fieldName}/{inputSystem}")]

--- a/backend/WebApi/Controllers/EntryController.cs
+++ b/backend/WebApi/Controllers/EntryController.cs
@@ -1,15 +1,15 @@
 using LanguageForge.WebApi.Dtos;
 using Microsoft.AspNetCore.Mvc;
+using static LanguageForge.WebApi.Controllers.PathConstants;
 
 namespace LanguageForge.WebApi.Controllers;
 
 [ApiController]
-[Route("api/[controller]/{projectCode}")]
+[Route($"api/[controller]/{{{ProjectCode}}}")]
 public class EntryController : ControllerBase
 {
-    // GET: api/Entry/{projectCode}
     [HttpGet]
-    public List<EntryDto> GetEntries(string projectCode)
+    public List<EntryDto> GetEntries()
     {
         return new() {
             new() {

--- a/backend/WebApi/Controllers/PathConstants.cs
+++ b/backend/WebApi/Controllers/PathConstants.cs
@@ -1,0 +1,6 @@
+namespace LanguageForge.WebApi.Controllers;
+
+public static class PathConstants
+{
+    public const string ProjectCode = "projectCode";
+}

--- a/backend/WebApi/Controllers/ProjectController.cs
+++ b/backend/WebApi/Controllers/ProjectController.cs
@@ -3,6 +3,7 @@ using LanguageForge.WebApi.Auth;
 using LanguageForge.WebApi.Dtos;
 using LanguageForge.WebApi.Services;
 using Microsoft.AspNetCore.Mvc;
+using static LanguageForge.WebApi.Controllers.PathConstants;
 
 namespace LanguageForge.WebApi.Controllers;
 
@@ -35,10 +36,10 @@ public class ProjectController : ControllerBase
     }
 
     // GET: api/Project/5
-    [HttpGet("{projectCode}")]
-    public string GetProject(string projectCode)
+    [HttpGet($"{{{ProjectCode}}}")]
+    public async Task<ProjectDto?> GetProject(string projectCode)
     {
-        return "value";
+        return await _projectService.GetProject(projectCode);
     }
 
     // POST: api/Project
@@ -48,14 +49,14 @@ public class ProjectController : ControllerBase
     }
 
     // PUT: api/Project/5
-    [HttpPut("{projectCode}")]
-    public void PutProject(string projectCode, [FromBody] string value)
+    [HttpPut($"{{{ProjectCode}}}")]
+    public void PutProject([FromBody] string value)
     {
     }
 
     // DELETE: api/Project/5
-    [HttpDelete("{projectCode}")]
-    public void DeleteProject(string projectCode)
+    [HttpDelete($"{{{ProjectCode}}}")]
+    public void DeleteProject()
     {
     }
 }

--- a/backend/WebApi/LfWebContext.cs
+++ b/backend/WebApi/LfWebContext.cs
@@ -1,18 +1,19 @@
 using LanguageForge.WebApi.Auth;
+using LanguageForge.WebApi.Controllers;
 
 namespace LanguageForge.WebApi;
 
 public interface ILfWebContext
 {
     /// <summary>
-    /// Authenticated user details
+    /// Authenticated user details. Null if the current user is not authenticated.
     /// </summary>
-    LfUser User { get; }
+    LfUser? User { get; }
 }
 
 public class LfWebContext : ILfWebContext
 {
-    public LfUser User { get; }
+    public LfUser? User { get; }
 
     public LfWebContext(IHttpContextAccessor httpContextAccessor)
     {
@@ -23,5 +24,21 @@ public class LfWebContext : ILfWebContext
         }
         User = JwtService.ExtractLfUser(httpContext.User);
     }
+}
 
+public interface ILfProjectContext
+{
+    public string? ProjectCode { get; }
+}
+
+public class LfProjectContext : ILfProjectContext
+{
+    public string? ProjectCode { get; }
+
+    public LfProjectContext(IHttpContextAccessor httpContextAccessor)
+    {
+        object? projectCode = null;
+        httpContextAccessor.HttpContext?.Request.RouteValues.TryGetValue(PathConstants.ProjectCode, out projectCode);
+        ProjectCode = projectCode?.ToString();
+    }
 }

--- a/backend/WebApi/Services/ProjectService.cs
+++ b/backend/WebApi/Services/ProjectService.cs
@@ -39,4 +39,12 @@ public class ProjectService
             .Project(_projectToDto)
             .ToListAsync();
     }
+
+    public async Task<ProjectDto?> GetProject(string projectCode)
+    {
+        return await _systemDbContext.Projects
+            .Find(p => p.ProjectCode == projectCode)
+            .Project(_projectToDto)
+            .SingleOrDefaultAsync();
+    }
 }

--- a/backend/WebApi/WebApiKernel.cs
+++ b/backend/WebApi/WebApiKernel.cs
@@ -11,5 +11,6 @@ public static class WebApiKernel
         services.AddSingleton<UserService>();
         services.AddHttpContextAccessor();
         services.AddScoped<ILfWebContext, LfWebContext>();
+        services.AddScoped<ILfProjectContext, LfProjectContext>();
     }
 }


### PR DESCRIPTION
Fixes #15

1) Create a Project-Context that can be injected globally to determine the current project.
2) Add a project-access policy that verifies the current user has access to the project